### PR TITLE
Update Key in licence docs for v15

### DIFF
--- a/15/umbraco-commerce/getting-started/the-licensing-model.md
+++ b/15/umbraco-commerce/getting-started/the-licensing-model.md
@@ -57,7 +57,7 @@ Once you have received your license code it needs to be installed on your site.
 
 1. Open the root directory for your project files.
 2. Locate and open the `appSettings.json` file.
-3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Umbraco.Commerce`:
+3. Add your Umbraco Commerce license key to `Umbraco:Licenses:Products:Umbraco.Commerce`:
 
 ```json
 "Umbraco": {


### PR DESCRIPTION
In v14 and v15 Umbraco Commerce has updated the JSON structure of the location of the licence key

'Products' has been added to the structure

Although this has been updated in the docs

Just above is a handy cut and paste key for the structure

However, 'Products:' has not been added to this key to match the new structure...

## Description

_What did you add/update/change?_

## Type of suggestion

* [ ] Typo/grammar fix
* [ ] Updated outdated content
* [ ] New content
* [ ] Updates related to a new version
* [ ] Other

## Product & version (if relevant)



## Deadline (if relevant)

_When should the content be published?_
